### PR TITLE
Implement accidente visualization module

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import AccidentMap from './components/AccidentMap';
 import Aire from './pages/Aire';
 import Traffic from './pages/Traffic';
 import Home from './pages/Home';
+import Accidentes from './pages/Accidentes';
 
 function Dashboard() {
   return (
@@ -55,6 +56,7 @@ function App() {
           <Link to="/" style={linkStyle}>Inicio</Link>
           <Link to="/dashboard" style={linkStyle}>Dashboard</Link>
           <Link to="/mapa" style={linkStyle}>Mapa</Link>
+          <Link to="/modulo/accidentes" style={linkStyle}>Accidentes</Link>
           <Link to="/modulo/aire" style={linkStyle}>Aire</Link>
           <Link to="/modulo/trafico" style={linkStyle}>Tráfico</Link>
         </nav>
@@ -64,6 +66,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/mapa" element={<MapView />} />
+        <Route path="/modulo/accidentes" element={<Accidentes />} />
         <Route path="/modulo/aire" element={<AireView />} />
         <Route path="/modulo/trafico" element={<TrafficView />} />
       </Routes>

--- a/frontend/src/components/FiltrosAccidentes.jsx
+++ b/frontend/src/components/FiltrosAccidentes.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+
+function FiltrosAccidentes({ distritos = [], initialFilters, onApply, onReset }) {
+  const [distrito, setDistrito] = useState(initialFilters.distrito || '');
+  const [dateFrom, setDateFrom] = useState(initialFilters.dateFrom || '');
+  const [dateTo, setDateTo] = useState(initialFilters.dateTo || '');
+
+  useEffect(() => {
+    setDistrito(initialFilters.distrito || '');
+    setDateFrom(initialFilters.dateFrom || '');
+    setDateTo(initialFilters.dateTo || '');
+  }, [initialFilters]);
+
+  const apply = () => {
+    onApply({ distrito, dateFrom, dateTo });
+  };
+
+  const reset = () => {
+    setDistrito('');
+    setDateFrom('');
+    setDateTo('');
+    onReset();
+  };
+
+  return (
+    <div style={{ marginBottom: '20px' }}>
+      <label style={{ marginRight: '10px' }}>
+        Distrito:
+        <select value={distrito} onChange={e => setDistrito(e.target.value)} style={{ marginLeft: '5px' }}>
+          <option value="">Todos</option>
+          {distritos.map(d => (
+            <option key={d} value={d}>{d}</option>
+          ))}
+        </select>
+      </label>
+      <label style={{ marginRight: '10px' }}>
+        Desde:
+        <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)} style={{ marginLeft: '5px' }} />
+      </label>
+      <label style={{ marginRight: '10px' }}>
+        Hasta:
+        <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)} style={{ marginLeft: '5px' }} />
+      </label>
+      <button onClick={apply} style={{ marginRight: '10px' }}>Aplicar filtros</button>
+      <button onClick={reset}>Resetear</button>
+    </div>
+  );
+}
+
+export default FiltrosAccidentes;

--- a/frontend/src/components/KpiAccidentes.jsx
+++ b/frontend/src/components/KpiAccidentes.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+function KpiAccidentes({ kpi }) {
+  if (!kpi) return null;
+  const { total, topDistrict, topType } = kpi;
+  return (
+    <div style={{ marginTop: '20px' }}>
+      <h3>KPIs</h3>
+      <ul>
+        <li><strong>Total accidentes:</strong> {total ?? '-'}</li>
+        <li><strong>Distrito con más accidentes:</strong> {topDistrict || '-'}</li>
+        <li><strong>Tipo más común:</strong> {topType || '-'}</li>
+      </ul>
+    </div>
+  );
+}
+
+export default KpiAccidentes;

--- a/frontend/src/components/MapaAccidentes.jsx
+++ b/frontend/src/components/MapaAccidentes.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+
+function MapaAccidentes({ accidents = [] }) {
+  return (
+    <MapContainer center={[40.4168, -3.7038]} zoom={11} style={{ height: '500px', width: '100%' }}>
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      {accidents.map((acc, idx) => (
+        acc.lat && acc.lng && (
+          <Marker key={idx} position={[acc.lat, acc.lng]}>
+            <Popup>
+              <div>
+                <strong>{acc.tipo_accidente}</strong><br />
+                Fecha: {acc.fecha?.slice(0, 10)}<br />
+                Distrito: {acc.distrito}<br />
+                Lesividad: {acc.lesividad}
+              </div>
+            </Popup>
+          </Marker>
+        )
+      ))}
+    </MapContainer>
+  );
+}
+
+export default MapaAccidentes;

--- a/frontend/src/pages/Accidentes.jsx
+++ b/frontend/src/pages/Accidentes.jsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import MapaAccidentes from '../components/MapaAccidentes';
+import FiltrosAccidentes from '../components/FiltrosAccidentes';
+import KpiAccidentes from '../components/KpiAccidentes';
+
+export default function Accidentes() {
+  const [distritos, setDistritos] = useState([]);
+  const [filters, setFilters] = useState({ distrito: '', dateFrom: '', dateTo: '' });
+  const [accidents, setAccidents] = useState([]);
+  const [kpi, setKpi] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/api/accidents/filters')
+      .then(res => setDistritos(res.data.distritos || []))
+      .catch(err => console.error('Error al cargar filtros:', err));
+  }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = {};
+        if (filters.distrito) params.distrito = filters.distrito;
+        if (filters.dateFrom) params.dateFrom = filters.dateFrom;
+        if (filters.dateTo) params.dateTo = filters.dateTo;
+        const [dataRes, kpiRes] = await Promise.all([
+          axios.get('http://localhost:5000/api/accidents/data', { params }),
+          axios.get('http://localhost:5000/api/accidents/kpi', { params })
+        ]);
+        setAccidents(dataRes.data || []);
+        setKpi(kpiRes.data);
+      } catch (err) {
+        console.error('Error al cargar accidentes:', err);
+        setError('Error al cargar datos');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [filters]);
+
+  const applyFilters = (f) => setFilters(f);
+  const resetFilters = () => setFilters({ distrito: '', dateFrom: '', dateTo: '' });
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>Accidentes</h2>
+      <FiltrosAccidentes
+        distritos={distritos}
+        initialFilters={filters}
+        onApply={applyFilters}
+        onReset={resetFilters}
+      />
+      {loading && <p>Cargando...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <MapaAccidentes accidents={accidents} />
+      <KpiAccidentes kpi={kpi} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Accidentes route to main `App`
- implement `MapaAccidentes` with Leaflet
- implement `FiltrosAccidentes` to filter by district and date
- implement `KpiAccidentes` for accident KPIs
- add `Accidentes` page tying everything together

## Testing
- `npm test --silent --watchAll=false` *(fails: react-scripts not found)*
- `npm install --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6851d40d63e08333b00722db81c57953