### PR TITLE
Add dashboard summary view

### DIFF
--- a/backend/controllers/dashboardController.js
+++ b/backend/controllers/dashboardController.js
@@ -1,0 +1,69 @@
+const BicycleFlow = require('../models/BicycleFlow');
+const ScooterAssignment = require('../models/ScooterAssignment');
+const Photovoltaic = require('../models/Photovoltaic');
+const RegulatedParkingStreet = require('../models/RegulatedParkingStreet');
+const Accident = require('../models/Accident');
+const AirData = require('../models/AirData');
+
+// GET /api/dashboard/summary
+const getDashboardSummary = async (req, res) => {
+  try {
+    // Consultas principales
+    const [
+      bicycles,
+      scooterAgg,
+      solar,
+      parkingAgg,
+      accidents
+    ] = await Promise.all([
+      BicycleFlow.countDocuments(),
+      ScooterAssignment.aggregate([{ $group: { _id: null, total: { $sum: '$TOTAL' } } }]),
+      Photovoltaic.countDocuments(),
+      RegulatedParkingStreet.aggregate([{ $group: { _id: null, total: { $sum: '$numPlazas' } } }]),
+      Accident.countDocuments()
+    ]);
+
+    const scooters = scooterAgg[0]?.total || 0;
+    const serSpaces = parkingAgg[0]?.total || 0;
+
+    // Calidad de aire promedio (NO2)
+    const airDocs = await AirData.aggregate([
+      { $match: { MAGNITUD: 1 } },
+      { $sort: { ANO: -1, MES: -1, DIA: -1 } },
+      { $group: { _id: '$PUNTO_MUESTREO', doc: { $first: '$$ROOT' } } }
+    ]);
+
+    let airSum = 0;
+    let airCount = 0;
+    airDocs.forEach(({ doc }) => {
+      for (let i = 1; i <= 24; i++) {
+        const hour = String(i).padStart(2, '0');
+        const value = doc[`H${hour}`];
+        const valid = doc[`V${hour}`];
+        if (valid === 'V' && value !== undefined && value !== null) {
+          const val = parseFloat(String(value).replace(',', '.'));
+          if (!isNaN(val)) {
+            airSum += val;
+            airCount++;
+          }
+        }
+      }
+    });
+
+    const airQuality = airCount > 0 ? parseFloat((airSum / airCount).toFixed(1)) : 0;
+
+    res.json({
+      bicycles,
+      scooters,
+      solar,
+      serSpaces,
+      accidents,
+      airQuality
+    });
+  } catch (err) {
+    console.error('Error in getDashboardSummary:', err);
+    res.status(500).json({ message: err.message });
+  }
+};
+
+module.exports = { getDashboardSummary };

--- a/backend/routes/dashboardRoutes.js
+++ b/backend/routes/dashboardRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { getDashboardSummary } = require('../controllers/dashboardController');
+
+router.get('/api/dashboard/summary', getDashboardSummary);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -26,6 +26,7 @@ const lostObjectRoutes = require('./routes/lostObjectRoutes');
 const taxiStopReservationRoutes = require('./routes/taxiStopReservationRoutes');
 const trafficDataRoutes = require('./routes/trafficDataRoutes');
 const locationRoutes = require('./routes/locationRoutes');
+const dashboardRoutes = require('./routes/dashboardRoutes');
 const app = express();
 
 // Middlewares
@@ -57,6 +58,7 @@ app.use('/api/lost-objects', lostObjectRoutes);
 app.use('/api/taxi-stop-reservations', taxiStopReservationRoutes);
 app.use('/api/traffic-data', trafficDataRoutes);
 app.use('/api/locations', locationRoutes);
-// Arrancar el servidor   
+app.use(dashboardRoutes);
+// Arrancar el servidor
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,24 +1,13 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 
-import DashboardCards from './components/DashboardCards';
-import AlertList from './components/AlertList';
+import Dashboard from './pages/Dashboard';
 import AccidentMap from './components/AccidentMap';
 import Aire from './pages/Aire';
 import SostenibilidadUrbana from './pages/SostenibilidadUrbana';
 import Home from './pages/Home';
 import Accidentes from './pages/Accidentes';
 
-function Dashboard() {
-  return (
-    <div style={{ padding: '20px' }}>
-      <h2>Dashboard General</h2>
-      <DashboardCards />
-      <h2 style={{ marginTop: '40px' }}>Alertas del Sistema</h2>
-      <AlertList />
-    </div>
-  );
-}
 
 function MapView() {
   return (

--- a/frontend/src/components/DashboardCards.js
+++ b/frontend/src/components/DashboardCards.js
@@ -2,32 +2,36 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 
 function DashboardCards() {
-  const [accidentsCount, setAccidentsCount] = useState(0);
-  const [bicyclesCount, setBicyclesCount] = useState(0);
-  const [trafficPointsCount, setTrafficPointsCount] = useState(0);
+  const [summary, setSummary] = useState({
+    bicycles: 0,
+    scooters: 0,
+    solar: 0,
+    serSpaces: 0,
+    accidents: 0,
+    airQuality: 0
+  });
 
   useEffect(() => {
-    // Obtener total de accidentes
-    axios.get('http://localhost:5000/api/accidents')
-      .then(res => setAccidentsCount(res.data.length))
-      .catch(err => console.error('Error al obtener accidentes:', err));
-
-    // Obtener total de disponibilidad bicicletas
-    axios.get('http://localhost:5000/api/bicycle-availability')
-      .then(res => setBicyclesCount(res.data.length))
-      .catch(err => console.error('Error al obtener bicicletas:', err));
-
-    // Obtener total de puntos de medición de tráfico
-    axios.get('http://localhost:5000/api/traffic-measurement-points')
-      .then(res => setTrafficPointsCount(res.data.length))
-      .catch(err => console.error('Error al obtener puntos de tráfico:', err));
+    axios.get('/api/dashboard/summary')
+      .then(res => setSummary(res.data))
+      .catch(err => console.error('Error al obtener resumen:', err));
   }, []);
 
   return (
-    <div style={{ display: 'flex', gap: '20px', padding: '20px' }}>
-      <Card title="Total Accidentes" value={accidentsCount} />
-      <Card title="Total Bicicletas" value={bicyclesCount} />
-      <Card title="Sensores de Tráfico" value={trafficPointsCount} />
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+        gap: '20px',
+        padding: '20px'
+      }}
+    >
+      <Card title="Total bicicletas registradas" value={summary.bicycles} />
+      <Card title="Total patinetes disponibles" value={summary.scooters} />
+      <Card title="Total instalaciones solares" value={summary.solar} />
+      <Card title="Total plazas SER" value={summary.serSpaces} />
+      <Card title="Total accidentes registrados" value={summary.accidents} />
+      <Card title="Calidad aire promedio (NO₂)" value={summary.airQuality} />
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -5,7 +5,7 @@ import AlertList from '../components/AlertList';
 export default function Dashboard() {
   return (
     <div style={{ padding: '20px' }}>
-      <h2>Dashboard General</h2>
+      <h2 style={{ textAlign: 'center' }}>Dashboard de Sostenibilidad Urbana</h2>
       <DashboardCards />
       <AlertList />
     </div>


### PR DESCRIPTION
## Summary
- aggregate KPI data in backend for dashboard
- expose new dashboard API route
- update server to use new route
- show 6 KPI cards in DashboardCards component
- add new Dashboard page with heading
- adjust App.js to use the page

## Testing
- `npm test` *(fails: no test specified)*
- `cd frontend && npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a347ac848333ad008d3355ae03d4