### PR TITLE
Enable remote access via env configuration

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -61,4 +61,4 @@ app.use('/api/locations', locationRoutes);
 app.use(dashboardRoutes);
 // Arrancar el servidor
 const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+app.listen(PORT, '0.0.0.0', () => console.log(`Server running on port ${PORT}`));

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://utopia-evolve.duckdns.org:5000

--- a/frontend/src/components/AccidentMap.js
+++ b/frontend/src/components/AccidentMap.js
@@ -2,13 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import axios from 'axios';
 import * as utm from 'utm';
+
+const API_BASE = process.env.REACT_APP_API_BASE;
 import 'leaflet/dist/leaflet.css';
 
 function AccidentMap() {
   const [accidents, setAccidents] = useState([]);
 
   useEffect(() => {
-    axios.get('http://localhost:5000/api/accidents')
+    axios.get(`${API_BASE}/api/accidents`)
       .then(res => {
         const filtered = res.data
           .filter(acc => acc.coordenada_x_utm && acc.coordenada_y_utm)

--- a/frontend/src/components/AlertList.js
+++ b/frontend/src/components/AlertList.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 
+const API_BASE = process.env.REACT_APP_API_BASE;
+
 function AlertList() {
   const [alerts, setAlerts] = useState([]);
 
@@ -10,7 +12,7 @@ function AlertList() {
 
       // Aire: NO2 > 180
       try {
-        const resAir = await axios.get('http://localhost:5000/api/air');
+        const resAir = await axios.get(`${API_BASE}/api/air`);
         const airData = resAir.data.filter(d => parseFloat(d.NO2?.replace(',', '.')) > 180);
         if (airData.length > 0) {
           newAlerts.push(`🚨 Calidad del aire crítica: ${airData.length} lecturas con NO₂ > 180`);
@@ -21,7 +23,7 @@ function AlertList() {
 
       // Tráfico: intensidad > 3000
       try {
-        const resTraffic = await axios.get('http://localhost:5000/api/traffic-data');
+        const resTraffic = await axios.get(`${API_BASE}/api/traffic-data`);
         const highTraffic = resTraffic.data.filter(d => d.intensidad > 3000);
         if (highTraffic.length > 0) {
           newAlerts.push(`🚦 Tráfico muy denso: ${highTraffic.length} lecturas con intensidad > 3000`);
@@ -32,7 +34,7 @@ function AlertList() {
 
       // Accidentes: más de 10 en un distrito
       try {
-        const resAccidents = await axios.get('http://localhost:5000/api/accidents');
+        const resAccidents = await axios.get(`${API_BASE}/api/accidents`);
         const distritos = {};
         resAccidents.data.forEach(acc => {
           if (!acc.distrito) return;

--- a/frontend/src/pages/Traffic.js
+++ b/frontend/src/pages/Traffic.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+
+const API_BASE = process.env.REACT_APP_API_BASE;
 import { Line } from 'react-chartjs-2';
 import 'chart.js/auto';
 
@@ -7,7 +9,7 @@ export default function Traffic() {
   const [datosPorHora, setDatosPorHora] = useState([]);
 
   useEffect(() => {
-    axios.get('http://localhost:5000/api/traffic-data')
+    axios.get(`${API_BASE}/api/traffic-data`)
       .then(res => {
         const registros = res.data;
 


### PR DESCRIPTION
## Summary
- allow backend to listen on all interfaces
- set frontend API base in `.env`
- use API base env variable in AlertList, AccidentMap, and Traffic components

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855adbe97bc83338165cd117317038c